### PR TITLE
handle CN=* in the otk_str, handle duplicates

### DIFF
--- a/opentoken/_utils.py
+++ b/opentoken/_utils.py
@@ -125,6 +125,16 @@ def otk_str_to_ordered_dict(otk_str):
         OrderedDict: OrderedDict representation of the token.
 
     """
-    items = otk_str.split("\n")
-    pairs = [tuple(line.split("=")) for line in items if line != ""]
-    return OrderedDict(pairs)
+    items = otk_str.rstrip().split("\n")
+    pairs = [tuple(filter(None,re.split(r"=(.+)?", line))) for line in items]
+
+    data = dict()
+    for key, value in pairs:
+        prevItem = data.get(key)
+        if (not prevItem):
+            data[key] = value
+        else:
+            previous = [prevItem] if type(prevItem) is not list else prevItem
+            data[key] = previous + [value]
+    return data 
+

--- a/opentoken/_utils.py
+++ b/opentoken/_utils.py
@@ -126,5 +126,5 @@ def otk_str_to_ordered_dict(otk_str):
 
     """
     items = otk_str.split("\n")
-    pairs = [tuple(line.split("=")) for line in items]
+    pairs = [tuple(line.split("=")) for line in items if line != ""]
     return OrderedDict(pairs)


### PR DESCRIPTION
openTraceback (most recent call last):
  File "opentoken_test.py", line 25, in <module>
    print(otkapi.parse_token(opentoken))
  File "/home/cristd02/.local/lib/python3.6/site-packages/opentoken/opentoken.py", line 43, in parse_token
    otk_str, self.cipher_suite_id, self.password
  File "/home/cristd02/.local/lib/python3.6/site-packages/opentoken/_token.py", line 182, in decode
    return _utils.otk_str_to_ordered_dict(payload.decode())
  File "/home/cristd02/.local/lib/python3.6/site-packages/opentoken/_utils.py", line 130, in otk_str_to_ordered_dict
    return OrderedDict(pairs)
ValueError: need more than 1 value to unpack
